### PR TITLE
add some usability options to download script

### DIFF
--- a/download-raw-minutes
+++ b/download-raw-minutes
@@ -50,8 +50,8 @@ else
 	done
 fi
 
-echo "..Downloading minutes for date=$DATE"
-echo "..Auto launch setting=$AUTO_LAUNCH"
+echo "....Downloading minutes for date=$DATE"
+echo "....Auto launch setting=$AUTO_LAUNCH"
 
 
 # Get the editor commands
@@ -61,11 +61,12 @@ echo "..Auto launch setting=$AUTO_LAUNCH"
 mkdir -p $DATE
 
 # Download raw logs and recordings
-echo "..Downloading IRC logs for $DATE..."
+echo "....Downloading IRC logs for $DATE..."
 curl -# "https://w3c-ccg.s3.digitalbazaar.com/minutes/$DATE-irc.log" > $DATE/irc.log
-echo "..Downloading audio recording for $DATE..."
+echo "....Downloading audio recording for $DATE..."
 curl -# "https://w3c-ccg.s3.digitalbazaar.com/minutes/$DATE-audio.wav" > $DATE/audio-raw.wav
 
+echo "Download is finished! To finalize the minutes, clean up the minutes/audio and publish."
 
 if [ "$AUTO_LAUNCH" = true ]; then
   # Edit the IRC log
@@ -76,6 +77,8 @@ if [ "$AUTO_LAUNCH" = true ]; then
 fi
 
 # Print out directions on finalizing minutes
-echo "To finalize the minutes, follow these instructions:"
-echo "   https://github.com/w3c-ccg/w3c-ccg.github.io/blob/master/irc_ref.md#publishing"
+echo "  Instructions for editing minutes and audio:"
+echo "    https://github.com/w3c-ccg/w3c-ccg.github.io/blob/master/irc_ref.md#edit"
+echo "  Instructions for publishing:"
+echo "    https://github.com/w3c-ccg/w3c-ccg.github.io/blob/master/irc_ref.md#publishing"
 

--- a/download-raw-minutes
+++ b/download-raw-minutes
@@ -2,7 +2,57 @@
 #
 # Fetches the raw minutes for cleanup
 
-DATE=`date +%Y-%m-%d`
+display_usage() { 
+	echo "Downloads raw minutes and audio for CCG group meetings." 
+	echo ""
+	echo "Usage: ./download-raw-minutes [-lh] [-d date]" 
+	echo "  -d [YYYY-MM-DD]     pass date argument"
+    echo "  -l                  launch audio and video editors programmatically"
+    echo "  -h                  display help"
+    echo ""
+    echo "Examples:"
+	echo ""
+    echo "  ./download-raw-minutes" 
+    echo "      downloads raw minutes and audio for the current date"
+    echo ""
+    echo "  ./download-raw-minutes -d 2018-05-15"
+    echo "      downloads raw minutes and audio for 15 May 2018"
+} 
+AUTO_LAUNCH=false
+CREATE_DIRECTORY=true
+
+if [ $# -eq 0 ]
+  then
+    echo "No date argument supplied; using current date"
+    DATE=`date +%Y-%m-%d`
+else
+	for i in "$@"
+	do
+	case $i in
+		--)
+	    display_usage
+	    exit 0
+	    ;;
+	    -h|--help)
+	    display_usage
+	    exit 0
+	    ;;
+	    -l|--autolaunch)
+	    AUTO_LAUNCH=true
+	    shift
+	    ;;
+	    -d|--date)
+		shift
+	    DATE=$1
+	    break
+	    ;;
+	esac
+	done
+fi
+
+echo "..Downloading minutes for date=$DATE"
+echo "..Auto launch setting=$AUTO_LAUNCH"
+
 
 # Get the editor commands
 . ./publishing.cfg
@@ -11,16 +61,19 @@ DATE=`date +%Y-%m-%d`
 mkdir -p $DATE
 
 # Download raw logs and recordings
-echo "Downloading IRC logs for $DATE..."
+echo "..Downloading IRC logs for $DATE..."
 curl -# "https://w3c-ccg.s3.digitalbazaar.com/minutes/$DATE-irc.log" > $DATE/irc.log
-echo "Downloading audio recording for $DATE..."
+echo "..Downloading audio recording for $DATE..."
 curl -# "https://w3c-ccg.s3.digitalbazaar.com/minutes/$DATE-audio.wav" > $DATE/audio-raw.wav
 
-# Edit the IRC log
-$EDITOR $DATE/irc.log &
 
-# Edit the audio recording
-$WAV_EDITOR $DATE/audio-raw.wav &
+if [ "$AUTO_LAUNCH" = true ]; then
+  # Edit the IRC log
+  $EDITOR $DATE/irc.log &
+
+  # Edit the audio recording
+  $WAV_EDITOR $DATE/audio-raw.wav &
+fi
 
 # Print out directions on finalizing minutes
 echo "To finalize the minutes, follow these instructions:"


### PR DESCRIPTION
Because it took me a lot of futzing to get the text and audio editors to autolaunch, I decided to add an option to skip autolaunching (i.e. it may be easier for people to just launch them manually.

I also added a `-d [DATE]` option in case someone wants minutes for a date other than the current date.

Note @msporny this has an impact on you because you now have to use the `-l` flag to autolaunch the editing tools (i.e. `download-raw-minutes -l`). 

That's because those were causing me (and I anticipate others) no end of confusion. That was primarily because the failure modes look really f-cking scary and might impose a psychological barrier to people helping out. :) For now, I thought the best workaround is to force a flag for auto-launching. 