### PR TITLE
Improvements to publish script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .DS_Store
+publishing.cfg
+scribe-tool/package-lock.json
+scribe-tool/node_modules/
+scribe-tool/irc.log

--- a/publishing.cfg.example
+++ b/publishing.cfg.example
@@ -4,14 +4,17 @@
 
 export EDITOR="/usr/bin/gedit"
 export WAV_EDITOR="/usr/bin/audacity"
+export NODE_COMMAND="nodejs"
 
 export SCRAWL_EMAIL_USERNAME=
 export SCRAWL_EMAIL_PASSWORD=
 export SCRAWL_EMAIL_SERVER=
+# Optional port and SSL. Default SSL is false
+# export SCRAWL_EMAIL_PORT=
+# export SCRAWL_EMAIL_SSL=
 export SCRAWL_TWITTER_CONSUMER_KEY=
 export SCRAWL_TWITTER_SECRET=
 export SCRAWL_TWITTER_TOKEN_KEY=
 export SCRAWL_TWITTER_TOKEN_SECRET=
 export SCRAWL_LINKEDIN_CLIENT_ID=
 export SCRAWL_LINKEDIN_CLIENT_SECRET=
-

--- a/scribe-tool/index.js
+++ b/scribe-tool/index.js
@@ -107,7 +107,7 @@ function sendEmail(email, username, password, hostname, content, callback, port=
   if(password.length > 3) {
     connectionOptions.password = password;
   }
-  if (port) {
+  if(port) {
     connectionOptions.port = port;
   }
 
@@ -200,7 +200,7 @@ async.waterfall([ function(callback) {
             }
 
             var dateMatch = item.match(/([0-9]{4}-[0-9]{2}-[0-9]{2}-?[^\/]*)/);
-            if (!dateMatch) {
+            if(!dateMatch) {
               // Skip processing
               return callback();
             }

--- a/scribe-tool/index.js
+++ b/scribe-tool/index.js
@@ -99,10 +99,6 @@ function postToWordpress(username, password, content, callback) {
 function sendEmail(email, username, password, hostname, content, callback, port=null, ssl=false, ) {
   var server = null;
 
-  //    self.host = host || self.host;
-  //  self.port = port || self.port;
-   // self.ssl = options.ssl || self.ssl;
-
   var connectionOptions = {
       user: username,
       host: hostname,
@@ -203,8 +199,8 @@ async.waterfall([ function(callback) {
               return callback(err);
             }
 
-            var isDateDir = item.match(/([0-9]{4}-[0-9]{2}-[0-9]{2}-?[^\/]*)/);
-            if (!isDateDir) {
+            var dateMatch = item.match(/([0-9]{4}-[0-9]{2}-[0-9]{2}-?[^\/]*)/);
+            if (!dateMatch) {
               // Skip processing
               return callback();
             }
@@ -226,7 +222,7 @@ async.waterfall([ function(callback) {
                 summary.resolution[j].replace(/resolved: /ig, '');
             }
 
-            var date = isDateDir[1];
+            var date = dateMatch[1];
             summaries[date] = summary;
             callback();
           });

--- a/scribe-tool/index.js
+++ b/scribe-tool/index.js
@@ -38,6 +38,7 @@ var peopleJson = fs.readFileSync(
 var gLogData = '';
 var gDate = path.basename(dstDir);
 gDate = gDate.match(/([0-9]{4}-[0-9]{2}-[0-9]{2})/)[1];
+console.log('gDate: ' + gDate);
 
 // configure scrawl
 scrawl.group = 'Credentials CG Telecon';
@@ -201,6 +202,12 @@ async.waterfall([ function(callback) {
               return callback(err);
             }
 
+            var isDateDir = item.match(/([0-9]{4}-[0-9]{2}-[0-9]{2}-?[^\/]*)/);
+            if (!isDateDir) {
+              console.log("Skipping processing of " + item);
+              return callback();
+            }
+
             // generate summary items
             var summary = {
               topic: [],
@@ -218,7 +225,7 @@ async.waterfall([ function(callback) {
                 summary.resolution[j].replace(/resolved: /ig, '');
             }
 
-            var date = item.match(/([0-9]{4}-[0-9]{2}-[0-9]{2}-?[^\/]*)/)[1];
+            var date = isDateDir[1];
             summaries[date] = summary;
             callback();
           });

--- a/scribe-tool/people.json
+++ b/scribe-tool/people.json
@@ -929,7 +929,7 @@
     "homepage": "https://www.linkedin.com/in/macted/"
   },
   "John Jordan": {
-    "alias": ["JohnJordan"],
+    "alias": ["JohnJordan", "John_Jordan_BCGov"],
     "homepage": "https://www.linkedin.com/in/johnjordandesign/"
   },
   "Pelle Brændgaard": {
@@ -985,7 +985,7 @@
     "homepage": "https://identitywoman.net/about-kaliya/bio/"
   },
   "David Challener": {
-    "alias": ["David_Challener"],
+    "alias": ["David_Challener", "dcc"],
     "homepage": "https://www.linkedin.com/in/dave-challener-bbab7b/"
   },
   "Dennis Yurkevich": {
@@ -1001,7 +1001,7 @@
     "homepage": "https://www.linkedin.com/in/cherieduncan"
   },
   "Jeff Orgel": {
-    "alias": ["jorgel"],
+    "alias": ["jorgel", "JeffO-StL"],
     "homepage": "https://www.linkedin.com/in/jeff-orgel-07820464/"
   },
   "Chris Boscolo": {
@@ -1017,11 +1017,11 @@
     "homepage": "https://www.linkedin.com/in/fuerve/"
   },
   "Yancy Ribbens": {
-    "alias": ["yribbens"],
+    "alias": ["yribbens", "Yancy"],
     "homepage": "https://www.linkedin.com/in/yancyribbens/"
   },
   "Anthony Ronning": {
-    "alias": ["aronning"],
+    "alias": ["aronning", "cycryptr_"],
     "homepage": "https://www.linkedin.com/in/anthonyronning/"
   },
   "Derek Munneke": {
@@ -1035,5 +1035,17 @@
   "Balázs Némethi": {
     "alias": ["balaz"],
     "homepage": "https://www.linkedin.com/in/balazsnemethi"
+  },
+  "Dmitri Zagidulin": {
+    "alias": ["dmitriz"],
+    "homepage": "https://www.linkedin.com/in/dzagidulin"
+  },
+  "Kayode Ezike": {
+    "alias": ["kezike"],
+    "homepage": "https://www.linkedin.com/in/kayodeezike/"
+  },
+  "Samantha Mathews Chase": {
+    "alias": ["SamanthaMatthewsChase"],
+    "homepage": "https://www.linkedin.com/in/samantha-mathews-2b478915/"
   }
 }

--- a/scribe-tool/people.json
+++ b/scribe-tool/people.json
@@ -96,7 +96,8 @@
     "alias": [
       "paroneayea",
       "cwebber",
-      "cwebber2"
+      "cwebber2",
+      "chris_webber"
     ],
     "homepage": "http://dustycloud.org/"
   },
@@ -605,7 +606,8 @@
     "alias": [
       "jandrieu",
       "JoeAndrieu",
-      "JoeA"
+      "JoeA",
+      "joe_andrieu"
     ],
     "homepage": "https://www.linkedin.com/in/joe-andrieu-a0528"
   },

--- a/scribe-tool/publish
+++ b/scribe-tool/publish
@@ -1,34 +1,105 @@
 #!/bin/bash
 #
 # Generates minutes for the directory given
+
+#!/bin/sh
+#
+# Fetches the raw minutes for cleanup
+
+# TODO: I passed directory, not date!!
+
+display_usage() { 
+	echo "Publish CCG minutes via email and social media." 
+	echo ""
+	echo "Usage: ./publish [-bh] [-d date]" 
+	echo "  -d [YYYY-MM-DD]     pass date argument"
+    echo "  -b                  broadcast output"
+    echo "  -h                  display help"
+    echo ""
+    echo "Examples:"
+	echo ""
+    echo "  ./publish" 
+    echo "      previews today's dates minutes and audio in preview mode (does not broadcast results)"
+    echo ""
+    echo "  ./publish -d 2018-05-15" 
+    echo "      previews 2018-05-15 minutes and audio in preview mode (does not broadcast results)"
+    echo ""
+    echo "  ./download-raw-minutes -b -d 2018-05-15"
+    echo "      publishes 2018-05-15 minutes and audio in preview mode (broadcasts results)"
+} 
+
+BROADCAST=false
+
+if [ $# -eq 0 ]
+  then
+    echo "No date argument supplied; using current date"
+    DATE=`date +%Y-%m-%d`
+else
+	for i in "$@"
+	do
+	case $i in
+		--)
+	    display_usage
+	    exit 0
+	    ;;
+	    -h|--help)
+	    display_usage
+	    exit 0
+	    ;;
+	    -b|--broadcast)
+	    BROADCAST=true
+	    shift
+	    ;;
+	    -d|--date)
+		shift
+	    DATE=$1
+	    break
+	    ;;
+	esac
+	done
+fi
+
+echo "....Publishing minutes for date=$DATE"
+echo "....Broadcast setting=$BROADCAST"
+
+
 source ../publishing.cfg
 
 echo "Generating minutes and social media posts for $1"
-DATESTR=`echo $1 | cut -f2 -d/`
-MESSAGE="Add text minutes and audio logs for $DATESTR telecon."
+# TODO
+MESSAGE="Add text minutes and audio logs for $DATE telecon."
+
+
+if [ -z "$NODE_COMMAND" ]; then
+    NODE_COMMAND="nodejs"
+    exit 1
+fi 
+echo "Node command: $NODE_COMMAND"
 
 # Generate minutes
-nodejs index.js -d $1 -m -i
-git add $1/irc.log $1/index.html $1/audio.ogg
-git commit $1/irc.log $1/index.html $1/audio.ogg $1/../index.html -m "$MESSAGE"
-git push
-
-# Generate G+ post summary
-#nodejs index.js -d $1 -w
-nodejs index.js -d $1 -g
+$NODE_COMMAND index.js -d $DATE -m -i
 
 # Make sure we want to continue
-read -e -p "Check for problems, press 'y' when ready to tweet/email: " -i "n" BROADCAST
+read -r -p "Check for problems, press 'y' when ready to commit to git, tweet/email: " BROADCAST
+
+echo "Broadcast: $BROADCAST"
 
 if [ "$BROADCAST" != "y" ]
 then
-   echo "Aborting social media broadcast."
+   echo "Aborting git commit and social media broadcast."
    exit
 fi
 
+git add ../$DATE/irc.log ../$DATE/index.html ../$DATE/audio.ogg
+git commit ../$DATE/irc.log ../$DATE/index.html ../$DATE/audio.ogg ../$DATE/../index.html -m "$MESSAGE"
+git push
+
+# Generate G+ post summary
+$NODE_COMMAND index.js -d $1 -w
+
 # Email minutes
-nodejs index.js -d $1 -e
+$NODE_COMMAND index.js -d $1 -e
 
 # Tweet telecon results
-nodejs index.js -d $1 -t 
+$NODE_COMMAND index.js -d $1 -t 
 

--- a/scribe-tool/publish
+++ b/scribe-tool/publish
@@ -6,34 +6,24 @@
 #
 # Fetches the raw minutes for cleanup
 
-# TODO: I passed directory, not date!!
-
 display_usage() { 
 	echo "Publish CCG minutes via email and social media." 
 	echo ""
-	echo "Usage: ./publish [-bh] [-d date]" 
-	echo "  -d [YYYY-MM-DD]     pass date argument"
-    echo "  -b                  broadcast output"
-    echo "  -h                  display help"
+	echo "Usage: ./publish [-h] [-d directory]" 
+	echo "  -d [/path/to/YYYY-MM-DD]     pass directory"
+    echo "  -h                           display help"
     echo ""
     echo "Examples:"
 	echo ""
-    echo "  ./publish" 
-    echo "      previews today's dates minutes and audio in preview mode (does not broadcast results)"
-    echo ""
-    echo "  ./publish -d 2018-05-15" 
+    echo "  ./publish -d /path/to/w3c-ccg-meeting/2018-05-15" 
     echo "      previews 2018-05-15 minutes and audio in preview mode (does not broadcast results)"
     echo ""
-    echo "  ./download-raw-minutes -b -d 2018-05-15"
-    echo "      publishes 2018-05-15 minutes and audio in preview mode (broadcasts results)"
 } 
-
-BROADCAST=false
 
 if [ $# -eq 0 ]
   then
-    echo "No date argument supplied; using current date"
-    DATE=`date +%Y-%m-%d`
+    display_usage
+    exit 1
 else
 	for i in "$@"
 	do
@@ -46,38 +36,36 @@ else
 	    display_usage
 	    exit 0
 	    ;;
-	    -b|--broadcast)
-	    BROADCAST=true
-	    shift
-	    ;;
-	    -d|--date)
+	    -d|--directory)
 		shift
-	    DATE=$1
+	    DIRECTORY=$1
 	    break
 	    ;;
 	esac
 	done
 fi
 
-echo "....Publishing minutes for date=$DATE"
-echo "....Broadcast setting=$BROADCAST"
+echo "....Publishing minutes for directory=$DIRECTORY"
 
+DATE="$(basename $DIRECTORY)"
 
 source ../publishing.cfg
 
-echo "Generating minutes and social media posts for $1"
-# TODO
+echo "Generating minutes and social media posts for $DATE"
 MESSAGE="Add text minutes and audio logs for $DATE telecon."
 
-
+# Add default values for missing env vars
 if [ -z "$NODE_COMMAND" ]; then
     NODE_COMMAND="nodejs"
-    exit 1
 fi 
-echo "Node command: $NODE_COMMAND"
+
+if [ -z "$SCRAWL_TO_EMAIL_ADDRESS" ]; then
+    SCRAWL_TO_EMAIL_ADDRESS="public-credentials@w3.org"
+fi 
+
 
 # Generate minutes
-$NODE_COMMAND index.js -d $DATE -m -i
+$NODE_COMMAND index.js -d $DIRECTORY -m -i
 
 # Make sure we want to continue
 read -r -p "Check for problems, press 'y' when ready to commit to git, tweet/email: " BROADCAST
@@ -90,16 +78,16 @@ then
    exit
 fi
 
-git add ../$DATE/irc.log ../$DATE/index.html ../$DATE/audio.ogg
-git commit ../$DATE/irc.log ../$DATE/index.html ../$DATE/audio.ogg ../$DATE/../index.html -m "$MESSAGE"
+git add $DIRECTORY/irc.log $DIRECTORY/index.html $DIRECTORY/audio.ogg
+git commit $DIRECTORY/irc.log $DIRECTORY/index.html $DIRECTORY/audio.ogg $DIRECTORY/../index.html -m "$MESSAGE"
 git push
 
 # Generate G+ post summary
-$NODE_COMMAND index.js -d $1 -w
+# $NODE_COMMAND index.js -d $1 -w
 
 # Email minutes
-$NODE_COMMAND index.js -d $1 -e
+$NODE_COMMAND index.js -d $DIRECTORY -e
 
 # Tweet telecon results
-$NODE_COMMAND index.js -d $1 -t 
+$NODE_COMMAND index.js -d $DIRECTORY -t 
 

--- a/scribe-tool/scrawl.js
+++ b/scribe-tool/scrawl.js
@@ -377,15 +377,19 @@
 
           // try to find the person by full name, last name, and then first name
           for(var i = 0; i < people.length; i++) {
-            var person = people[i].replace(/^\s/, '').replace(/\s$/, '');
-            var lastName = person.split(' ')[1];
-            var firstName = person.split(' ')[0];
-            if(person in aliases) {
-              scrawl.present(context, aliases[person]);
-            } else if(lastName in aliases) {
-              scrawl.present(context, aliases[lastName]);
+            if (!people[i]) {
+              scrawl.present(context, aliases[nick]);
             } else {
-              console.log('Could not find alias for', person);
+              var person = people[i].replace(/^\s/, '').replace(/\s$/, '');
+              var lastName = person.split(' ')[1];
+              var firstName = person.split(' ')[0];
+              if(person in aliases) {
+                scrawl.present(context, aliases[person]);
+              } else if(lastName in aliases) {
+                scrawl.present(context, aliases[lastName]);
+              } else {
+                console.log('Could not find alias for', person);
+              }
             }
           }
        }


### PR DESCRIPTION
- Additions to people.json
- Make some more options configurable, e.g. "to" email address for testing
- Move github commit after "yes to continue"
- Allow SSL and port settings for email
- Comment out g+ stuff -- probably not used?
- Use writer nickname for people who write `present+` rather than `present+ name`

@msporny this should be backwards compatible for you to run through the `./publish` script. I used your previous options as defaults for new environment variables (that aren't in the .cfg file).