### PR TITLE
Switch to github actions to publish minutes

### DIFF
--- a/.github/workflows/download_raw_minutes.yml
+++ b/.github/workflows/download_raw_minutes.yml
@@ -1,0 +1,50 @@
+name: Download raw minutes
+
+on:
+  repository_dispatch:
+    types: download_minutes
+  #schedule:
+  #  - cron:  '*/5 * * * *'
+  # 0 18 * * TUE
+
+jobs:
+  download-minutes:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Setup custom environment variables
+      run: git config --global push.default simple && git config --global user.email "w3c.ccg@gmail.com" && git config --global user.name "W3C CCG"
+    - name: Pull raw meeting log file
+      id: pull_raw_file
+      env: 
+        DATE: ${{ github.event.client_payload.date }}
+      run: |
+        bash ./download-minutes.sh
+        echo "##[set-output name=date;]${DATE}"
+
+    - uses: stefanzweifel/git-auto-commit-action@v2.5.0
+      with:
+        commit_message: Add raw log for telecon [ci skip]
+        branch: gh-pages
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Send email
+      uses: dawidd6/action-send-mail@v1.3.0
+   
+      with:
+        server_address: smtp.gmail.com
+        server_port: 465
+        username: w3c.ccg
+        password: ${{ secrets.password }}
+        subject: ${{ format('[ACTION - clean up raw minutes] W3C Credentials CG Call - {0} 12pm ET', steps.pull_raw_file.outputs.date) }}
+        body: ${{ format('Go to scribe-tool (https://w3c-ccg.github.io/meetings/scribe-tool/), paste in the contents of https://github.com/w3c-ccg/meetings/blob/gh-pages/{0}/irc-raw.log, clean it up, save results in irc.log (same folder) and commit.', steps.pull_raw_file.outputs.date) }}
+        to: kimdhamilton@gmail.com, ChristopherA@lifewithalacrity.com, joe@legreq.com
+        from: w3c.ccg@gmail.com
+
+
+
+
+

--- a/.github/workflows/download_raw_minutes.yml
+++ b/.github/workflows/download_raw_minutes.yml
@@ -38,7 +38,7 @@ jobs:
         server_address: smtp.gmail.com
         server_port: 465
         username: w3c.ccg
-        password: ${{ secrets.password }}
+        password: ${{ secrets.email_password }}
         subject: ${{ format('[ACTION - clean up raw minutes] W3C Credentials CG Call - {0} 12pm ET', steps.pull_raw_file.outputs.date) }}
         body: ${{ format('Go to scribe-tool (https://w3c-ccg.github.io/meetings/scribe-tool/), paste in the contents of https://github.com/w3c-ccg/meetings/blob/gh-pages/{0}/irc-raw.log, clean it up, save results in irc.log (same folder) and commit.', steps.pull_raw_file.outputs.date) }}
         to: kimdhamilton@gmail.com, ChristopherA@lifewithalacrity.com, joe@legreq.com

--- a/.github/workflows/publish_minutes.yml
+++ b/.github/workflows/publish_minutes.yml
@@ -1,0 +1,75 @@
+name: Publish minutes
+
+on:
+  push:
+    paths:
+    - '**/irc.log'
+
+jobs:
+  generate-html:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - id: file_changes
+      uses: trilom/file-changes-action@v1
+      with:
+        githubToken: ${{ secrets.GITHUB_TOKEN }}
+    - name: detect_file
+      id: detect_file
+      run: |
+        echo ${{ steps.file_changes.outputs.files_modified}}
+        echo ${{ steps.file_changes.outputs.files_added }}
+        arr=${{ steps.file_changes.outputs.files_added }}
+        echo arr
+        new_file=${arr[0]}
+        echo $new_file
+        output=${new_file:1:10}
+        echo $output
+        echo "##[set-output name=date;]${output}"
+      shell: bash
+    - name: Setup custom environment variables
+      run: git config --global push.default simple && git config --global user.email "w3c.ccg@gmail.com" && git config --global user.name "W3C CCG"
+    - name: Generate html minutes
+      id: generate_html_minutes
+      run: |
+        npm install
+        bash ./generate-html.sh
+        echo "##[set-output name=date;]${DATE}"
+      env:
+        CI: true
+        DATE: ${{ steps.detect_file.outputs.date }}
+        
+    - uses: stefanzweifel/git-auto-commit-action@v2.5.0
+      with:
+        commit_message: Add html minutes for telecon [ci skip]
+        branch: gh-pages
+
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Send email
+      uses: dawidd6/action-send-mail@v1.3.0
+   
+      with:
+        server_address: smtp.gmail.com
+        server_port: 465
+        username: w3c.ccg
+        password: ${{ secrets.password }}
+        subject: ${{ format('[MINUTES] W3C Credentials CG Call - {0} 12pm ET', steps.generate_html_minutes.outputs.date) }}
+        body: ${{ format('file://{0}/email.log', steps.generate_html_minutes.outputs.date) }}
+        to: w3c.ccg@gmail.com
+        from: w3c.ccg@gmail.com
+          
+    - name: Twitter Action
+      uses: ethomson/send-tweet-action@v1
+      with:
+        status: ${{ format('Credentials CG Minutes Available https://w3c-ccg.github.io/meetings/{0}', steps.generate_html_minutes.outputs.date) }}
+        consumer-key: ${{ secrets.twitter_api_key }}
+        consumer-secret: ${{ secrets.twitter_api_secret }}
+        access-token: ${{ secrets.twitter_access_token }}
+        access-token-secret: ${{ secrets.twitter_access_token_secret }}

--- a/.github/workflows/publish_minutes.yml
+++ b/.github/workflows/publish_minutes.yml
@@ -59,7 +59,7 @@ jobs:
         server_address: smtp.gmail.com
         server_port: 465
         username: w3c.ccg
-        password: ${{ secrets.password }}
+        password: ${{ secrets.email_password }}
         subject: ${{ format('[MINUTES] W3C Credentials CG Call - {0} 12pm ET', steps.generate_html_minutes.outputs.date) }}
         body: ${{ format('file://{0}/email.log', steps.generate_html_minutes.outputs.date) }}
         to: w3c.ccg@gmail.com

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,496 @@
+{
+  "name": "scrawl",
+  "version": "0.3.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "addressparser": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/addressparser/-/addressparser-0.3.2.tgz",
+      "integrity": "sha1-WYc/Nej89sc2HBAjkmHXbhU0i7I="
+    },
+    "async": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+      "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "dev": true
+    },
+    "commander": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-1.0.5.tgz",
+      "integrity": "sha1-RXKVu5duOI6d0NtS3kMz4knz2Iw=",
+      "requires": {
+        "keypress": "0.1.x"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "cookies": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.8.0.tgz",
+      "integrity": "sha512-8aPsApQfebXnuI+537McwYsDtjVxGm8gTIzQI3FDW6t5t/DAhERxtnbEPN/8RX+uZthoz4eCOgloXaE5cYyNow==",
+      "requires": {
+        "depd": "~2.0.0",
+        "keygrip": "~1.1.0"
+      }
+    },
+    "cycle": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI=",
+      "dev": true
+    },
+    "deep-equal": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
+      "integrity": "sha1-hLdFiW80xoTpjyzg5Cq69Du6AX0=",
+      "dev": true
+    },
+    "depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+    },
+    "emailjs": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/emailjs/-/emailjs-2.2.0.tgz",
+      "integrity": "sha1-ulsj5KSwpFEPZS6HOxVOlAe2ygM=",
+      "requires": {
+        "addressparser": "^0.3.2",
+        "emailjs-mime-codec": "^2.0.7"
+      }
+    },
+    "emailjs-base64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/emailjs-base64/-/emailjs-base64-1.1.4.tgz",
+      "integrity": "sha512-4h0xp1jgVTnIQBHxSJWXWanNnmuc5o+k4aHEpcLXSToN8asjB5qbXAexs7+PEsUKcEyBteNYsSvXUndYT2CGGA=="
+    },
+    "emailjs-mime-codec": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/emailjs-mime-codec/-/emailjs-mime-codec-2.0.9.tgz",
+      "integrity": "sha512-7qJo4pFGcKlWh/kCeNjmcgj34YoJWY0ekZXEHYtluWg4MVBnXqGM4CRMtZQkfYwitOhUgaKN5EQktJddi/YIDQ==",
+      "requires": {
+        "emailjs-base64": "^1.1.4",
+        "ramda": "^0.26.1",
+        "text-encoding": "^0.7.0"
+      }
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "~0.4.13"
+      }
+    },
+    "eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "html-entities": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.0.10.tgz",
+      "integrity": "sha1-DepZEw3VDfFU6CxM9x0Iwsnclos="
+    },
+    "i": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/i/-/i-0.3.6.tgz",
+      "integrity": "sha1-2WyScyB28HJxG2sQ/X1PZa2O4j0=",
+      "dev": true
+    },
+    "iconv": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/iconv/-/iconv-2.3.5.tgz",
+      "integrity": "sha512-U5ajDbtDfadp7pvUMC0F2XbkP5vQn9Xrwa6UptePl+cK8EILxapAt3sXers9B3Gxagk+zVjL2ELKuzQvyqOwug==",
+      "optional": true,
+      "requires": {
+        "nan": "^2.14.0",
+        "safer-buffer": "^2.1.2"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
+    "keygrip": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
+      "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
+      "requires": {
+        "tsscmp": "1.0.6"
+      }
+    },
+    "keypress": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz",
+      "integrity": "sha1-SjGI1CkbZrT2XtuZ+AaqmuKTWSo="
+    },
+    "mailparser": {
+      "version": "0.2.33",
+      "resolved": "https://registry.npmjs.org/mailparser/-/mailparser-0.2.33.tgz",
+      "integrity": "sha1-f71f1+8lznSP3qU2I/Din22bCQs=",
+      "requires": {
+        "encoding": ">=0.1.4",
+        "iconv": "*",
+        "mime": "*",
+        "mimelib": ">=0.2.6"
+      }
+    },
+    "mime": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+      "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
+    },
+    "mimelib": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/mimelib/-/mimelib-0.3.1.tgz",
+      "integrity": "sha1-eHrdJBXYJ6yzr27EvKHqlZZBiFM=",
+      "requires": {
+        "addressparser": "~1.0.1",
+        "encoding": "~0.1.12"
+      },
+      "dependencies": {
+        "addressparser": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/addressparser/-/addressparser-1.0.1.tgz",
+          "integrity": "sha1-R6++GiqSYhkdtoOOT9HTm0CCF0Y="
+        }
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+    },
+    "mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
+    },
+    "nan": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+      "optional": true
+    },
+    "ncp": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-1.0.1.tgz",
+      "integrity": "sha1-0VNn5cuHQyuhF9K/gP30Wuz7QkY=",
+      "dev": true
+    },
+    "oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha1-vR/vr2hslrdUda7VGWQS/2DPucE="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "pkginfo": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.1.tgz",
+      "integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8=",
+      "dev": true
+    },
+    "prompt": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prompt/-/prompt-1.0.0.tgz",
+      "integrity": "sha1-jlcSPDlquYiJf7Mn/Trtw+c15P4=",
+      "dev": true,
+      "requires": {
+        "colors": "^1.1.2",
+        "pkginfo": "0.x.x",
+        "read": "1.0.x",
+        "revalidator": "0.1.x",
+        "utile": "0.3.x",
+        "winston": "2.1.x"
+      }
+    },
+    "ramda": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
+      "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ=="
+    },
+    "read": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+      "dev": true,
+      "requires": {
+        "mute-stream": "~0.0.4"
+      }
+    },
+    "revalidator": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
+      "integrity": "sha1-/s5hv6DBtSoga9axgZgYS91SOjs=",
+      "dev": true
+    },
+    "rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "sax": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-0.4.3.tgz",
+      "integrity": "sha1-cA46NOsueSzjgHkccSgPNzGWXdw="
+    },
+    "sprintf": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/sprintf/-/sprintf-0.1.5.tgz",
+      "integrity": "sha1-j4PjmpMXwaUCy324BQ5Rxnn27c8=",
+      "dev": true
+    },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+      "dev": true
+    },
+    "text-encoding": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.7.0.tgz",
+      "integrity": "sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA=="
+    },
+    "tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA=="
+    },
+    "twitter": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/twitter/-/twitter-0.2.13.tgz",
+      "integrity": "sha1-KcwBmV9aQV99X3guLGo2uCAMs4w=",
+      "requires": {
+        "cookies": ">=0.1.6",
+        "keygrip": ">=0.1.7",
+        "oauth": ">=0.8.4"
+      }
+    },
+    "underscore": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.5.2.tgz",
+      "integrity": "sha1-EzXF5PXm0zu7SwBrqMhqAPVW3gg="
+    },
+    "utile": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/utile/-/utile-0.3.0.tgz",
+      "integrity": "sha1-E1LDQOuCDk2N26A5pPv6oy7U7zo=",
+      "dev": true,
+      "requires": {
+        "async": "~0.9.0",
+        "deep-equal": "~0.2.1",
+        "i": "0.3.x",
+        "mkdirp": "0.x.x",
+        "ncp": "1.0.x",
+        "rimraf": "2.x.x"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+          "dev": true
+        }
+      }
+    },
+    "validator": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-1.2.2.tgz",
+      "integrity": "sha1-Kj3swhgG4Vjbl51E5ITUO6MAoWQ="
+    },
+    "winston": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.1.1.tgz",
+      "integrity": "sha1-PJNJ0ZYgf9G9/51LxD73JRDjoS4=",
+      "dev": true,
+      "requires": {
+        "async": "~1.0.0",
+        "colors": "1.0.x",
+        "cycle": "1.0.x",
+        "eyes": "0.1.x",
+        "isstream": "0.1.x",
+        "pkginfo": "0.3.x",
+        "stack-trace": "0.0.x"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+          "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
+          "dev": true
+        },
+        "colors": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+          "dev": true
+        },
+        "pkginfo": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
+          "integrity": "sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE=",
+          "dev": true
+        }
+      }
+    },
+    "wporg": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wporg/-/wporg-0.1.0.tgz",
+      "integrity": "sha1-v26T86hIn145UBqaJIi3m3fK5iI=",
+      "requires": {
+        "underscore": "~1.4.4",
+        "validator": "~1.2.0",
+        "xmlrpc": "~1.1.0"
+      },
+      "dependencies": {
+        "underscore": {
+          "version": "1.4.4",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
+          "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
+        }
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "xmlbuilder": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz",
+      "integrity": "sha1-F3bWXz/brUcKCNhgTN6xxOVA/4M="
+    },
+    "xmlrpc": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/xmlrpc/-/xmlrpc-1.1.1.tgz",
+      "integrity": "sha1-dPBetNL1QjwN3P9n1oe1w9rFt34=",
+      "requires": {
+        "sax": "0.4.x",
+        "xmlbuilder": "0.4.2"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "scrawl",
+  "version": "0.3.0",
+  "private": true,
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "async": "~0.2.9",
+    "commander": "~1.0.0",
+    "emailjs": "^2.2.0",
+    "html-entities": "~1.0.10",
+    "mailparser": "~0.2.26",
+    "mime": "^2.4.0",
+    "moment": "^2.23.0",
+    "twitter": "~0.2.5",
+    "underscore": "~1.5.0",
+    "wporg": "~0.1.0"
+  },
+  "devDependencies": {
+    "prompt": "^1.0.0",
+    "sprintf": "~0.1.0"
+  }
+}

--- a/scribe-tool/scrawl.js
+++ b/scribe-tool/scrawl.js
@@ -388,7 +388,8 @@
               } else if(lastName in aliases) {
                 scrawl.present(context, aliases[lastName]);
               } else {
-                console.log('Could not find alias for', person);
+                scrawl.present(context, person);
+                //console.log('Could not find alias for', person);
               }
             }
           }
@@ -569,9 +570,17 @@
 
     // build the list of people present
     for(var name in context.present) {
-      var person = scrawl.people[name]
-      person['name'] = name;
-      present.push(person)
+      if (name in scrawl.people) {
+        var person = scrawl.people[name];
+        person['name'] = name;
+        present.push(person);
+      } else if (name) {
+        console.warn('Could not find alias for', name);
+        var person = {};
+        person['name'] = name;
+        present.push(person);
+      }
+
     }
 
     // modify the time if it was specified
@@ -638,7 +647,7 @@
       }
 
       // generate the list of people present
-      var peoplePresent = ''
+      var peoplePresent = '';
       for(var i = 0; i < present.length; i++) {
         var person = present[i];
 
@@ -646,8 +655,11 @@
           peoplePresent += ', ';
         }
 
-        peoplePresent += '<a href="' + person.homepage + '">'+
-          person.name + '</a>'
+        if (person.homepage) {
+          peoplePresent += '<a href="' + person.homepage + '">' + person.name + '</a>';
+        } else {
+          peoplePresent += person.name;
+        }
       }
       if(context.totalPresent) {
         peoplePresent += ', ' + context.totalPresent;


### PR DESCRIPTION
There are 2 distinct phases

1. Download raw minutes for date
    - Trigger: currently a curl command (see below)
    - Actions:
        - Download minutes for <date>
        - Email the chairs to clean up the minutes with helpful links

2. Publish the minutes for date
    - Trigger: Kicks off when chairs checkin cleaned up irc.log file
    - Does the following:
         - Generates html minutes
         - Emails summary to ccg email group
         - Tweets



```
curl -H "Accept: application/vnd.github.everest-preview+json" \
    -H "Authorization: token <token>" \
    --request POST \
    --data '{"event_type": "download_minutes", "client_payload": { "date": "<date>"}}' \
    https://api.github.com/repos/w3c-ccg/meetings/dispatches
```