### PR TITLE
Make scribe-tool more smarterer

### DIFF
--- a/scribe-tool/index.html
+++ b/scribe-tool/index.html
@@ -19,6 +19,23 @@
 var updateCounter = 0;
 var updateCounterTimeout = null;
 
+// get irc log from URL
+fetchLog = function(dateString){
+  const url = "https://meet.w3c-ccg.org/archives/w3c-ccg-weekly-"+dateString+"-irc.log";
+  fetch(url)
+    .then(res => res.text())
+    .then(res => {
+      $('#irc-log').val(res);
+      $('#form-resp').removeClass('error').text('');
+      displayMinutes();
+    })
+    .catch(err => {
+      console.error('Error:', err);
+      $('#form-resp').addClass('error').text('No minutes on that date');
+      $('#irc-log').val('');
+    });
+};
+
 // generates and outputs the minutes to the HTML output
 displayMinutes = function() {
   var ircLog = $('#irc-log').val()
@@ -76,10 +93,46 @@ showMarkup = function(type) {
   }
 }
 
+copyText = async function(){
+  if($('#irc-log').is(':visible')){
+    var toCopy = $('#irc-log').val();
+  }else if($('#text-markup').is(':visible')){
+    var toCopy = $('#text-markup').val();
+  }else if($('#html-markup').is(':visible')){
+    var toCopy = $('#html-markup').val();
+  }
+  try {
+    await navigator.clipboard.writeText(toCopy);
+    $('#btn-resp').text('copied').fadeIn('fast').delay(1000).fadeOut('slow');
+  } catch (error) {
+    console.error("copy failed", error);
+  }
+}
+
 // initialize scrawl
 $.getJSON( "people.json", function(people) {
   scrawl.group = "Credentials Community Group";
   scrawl.people = people;
+});
+
+$(function(){
+
+  // look for date in URL
+  let params = new URLSearchParams(location.search);
+  let date = params.get("date");
+  if(date == undefined || isNaN(Date.parse(date))){
+    // set default form date to today
+    let [month, date, year] = new Date().toLocaleDateString("en-US").split("/")
+    $('#date').val(year+'-'+month+'-'+date);
+  }else{
+    $('#date').val(date);
+    fetchLog(date);
+  }
+
+  $('#fetch-by-date').submit(function(e){
+    e.preventDefault();
+    fetchLog($('#date').val());
+  });
 });
   </script>
 </head>
@@ -104,6 +157,14 @@ $.getJSON( "people.json", function(people) {
       <div class="button" onclick="javascript:showMarkup('raw')">Show Raw Log</div>
       <div class="button" onclick="javascript:showMarkup('html')">Show HTML</div>
       <div class="button" onclick="javascript:showMarkup('text')">Show Text</div>
+
+      <form id="fetch-by-date">
+        <input type="date" name="date" id="date" />
+        <input type="submit" class="button" value="Fetch by date" />
+      </form>
+      <p id="form-resp"></p>
+      <span class="button" onclick="javascript:copyText()">Copy</span>
+      <span id="btn-resp"></span>
    </span>
 </section>
 

--- a/scribe-tool/index.html
+++ b/scribe-tool/index.html
@@ -33,13 +33,16 @@ fetchLog = function(dateString){
       console.error('Error:', err);
       $('#form-resp').addClass('error').text('No minutes on that date');
       $('#irc-log').val('');
+      $('#text-markup').val('');
+      $('#html-markup').val('');
+      $('#html-output').html('');
     });
 };
 
 // generates and outputs the minutes to the HTML output
 displayMinutes = function() {
   var ircLog = $('#irc-log').val()
-  minutes = scrawl.generateMinutes(ircLog, 'html');
+  minutes = scrawl.generateMinutes(ircLog, 'html', $('#date').val());
 
   $('#html-output').html(minutes);
 };
@@ -68,7 +71,7 @@ showMarkup = function(type) {
   // Display the appropriate markup text area based on the 'type'
   if(type == 'html')
   {
-    var html = scrawl.htmlHeader + scrawl.generateMinutes(ircLog, 'html') +
+    var html = scrawl.htmlHeader + scrawl.generateMinutes(ircLog, 'html', $('#date').val()) +
       scrawl.htmlFooter;
 
     $('#irc-log').hide();
@@ -78,7 +81,7 @@ showMarkup = function(type) {
   }
   else if(type == 'text')
   {
-    var text = scrawl.generateMinutes(ircLog, 'text')
+    var text = scrawl.generateMinutes(ircLog, 'text', $('#date').val())
 
     $('#html-markup').hide();
     $('#irc-log').hide();

--- a/scribe-tool/scrawl.js
+++ b/scribe-tool/scrawl.js
@@ -528,9 +528,8 @@
            }
            else
            {
-             rval = scrawl.error(
-               '(IRC nickname \'' + nick + '\' not recognized)' + line,
-               textMode);
+             rval = scrawl.information('<'+nick+'> '+msg, textMode);
+             context.unrecognized.add(nick);
            }
          }
          else
@@ -763,7 +762,8 @@
       'topics': [],
       'resolutions': [],
       'actions': [],
-      'audio': true
+      'audio': true,
+      'unrecognized': new Set()
     };
 
     if(date) {
@@ -777,6 +777,13 @@
     {
       var line = ircLines[i];
       minutes += scrawl.processLine(context, aliases, line, textMode);
+    }
+
+    if(context.unrecognized.size > 0){
+      console.log('WARNING: Unrecognized nicks - please add to people.json\n');
+      context.unrecognized.forEach(function(value){
+        console.log('\t'+value+'\n');
+      });
     }
 
     // generate the meeting summary


### PR DESCRIPTION
Updates scribe-tool to makes irc-log downloader scripts redundant:

* automatically fetches and prepopulates itself with the IRC logs from today's date on load (if available) 
* offers a date selector so you can fetch logs from any chosen date with a click
* takes a `?date=yyyy-mm-dd` URL parameter and prepopulates itself from that, so you can link to it preconfigured for a specific meeting

Bonus:

* (bugfix) displays the correct date in the generated HTML heading
* (improvement) lists unrecognized nicks in the console and reminds you to put them in people.json