### PR TITLE
scribe-tool: Add button to download audio

### DIFF
--- a/scribe-tool/index.html
+++ b/scribe-tool/index.html
@@ -27,6 +27,7 @@ fetchLog = function(dateString){
     .then(res => {
       $('#irc-log').val(res);
       $('#form-resp').removeClass('error').text('');
+      $('#btn-audio').removeAttr('disabled');
       displayMinutes();
     })
     .catch(err => {
@@ -36,6 +37,7 @@ fetchLog = function(dateString){
       $('#text-markup').val('');
       $('#html-markup').val('');
       $('#html-output').html('');
+      $('#btn-audio').prop('disabled', true);
     });
 };
 
@@ -112,6 +114,13 @@ copyText = async function(){
   }
 }
 
+downloadAudio = function(){
+  var audioUrl = "https://meet.w3c-ccg.org/archives/w3c-ccg-weekly-";
+  // get date from date input
+  audioUrl = audioUrl + $('#date').val() + ".ogg";
+  window.open(audioUrl, '_blank');
+}
+
 // initialize scrawl
 $.getJSON( "people.json", function(people) {
   scrawl.group = "Credentials Community Group";
@@ -168,6 +177,8 @@ $(function(){
       <p id="form-resp"></p>
       <span class="button" onclick="javascript:copyText()">Copy</span>
       <span id="btn-resp"></span>
+
+      <button id="btn-audio" disabled class="button" onclick="javascript:downloadAudio()">download audio</div>
    </span>
 </section>
 


### PR DESCRIPTION
The button is available when a date with a valid IRC meeting log is present, and disabled otherwise. It uses the date to complete the URL to the ogg file, and just opens it in a new tab. This can then be saved easily from the browser (ctrl+s, etc).

Towards https://github.com/w3c-ccg/meetings/issues/23

![Screenshot at 2020-12-01 20-10-02](https://user-images.githubusercontent.com/466229/100791483-38628080-3411-11eb-9f1b-dfc0bf1e0519.png)
