### PR TITLE
[Optional] add configurable chair list for task forces

### DIFF
--- a/scribe-tool/config.json
+++ b/scribe-tool/config.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name": "Credentials CG",
+    "chairs": ["Wayne Chang", "Kim Hamilton Duffy", "Heather Vescent"]
+  },
+  {
+    "name": "CCG Verifiable Credentials for Education Task Force",
+    "chairs": ["Anthony Camilleri", "Kim Hamilton Duffy"]
+  }
+]

--- a/scribe-tool/index.js
+++ b/scribe-tool/index.js
@@ -4,6 +4,7 @@ var fs = require('fs');
 var path = require('path');
 var program = require('commander');
 var scrawl = require('./scrawl');
+var config = require('./config.json');
 
 program
   .version('0.3.0')
@@ -33,10 +34,13 @@ var peopleJson = fs.readFileSync(
 var gLogData = '';
 var gDate = path.basename(dstDir);
 gDate = gDate.match(/([0-9]{4}-[0-9]{2}-[0-9]{2})/)[1];
+var groupConfig = _.find(config, c => c.name === program.group);
 
 // configure scrawl
 scrawl.group = `${program.group} Telecon`;
 scrawl.people = JSON.parse(peopleJson);
+scrawl.chairs = groupConfig.chairs;
+
 
 function generateEmailBody() {
 // generate the body of the email

--- a/scribe-tool/scrawl.js
+++ b/scribe-tool/scrawl.js
@@ -761,8 +761,7 @@
     var context =
     {
       'group': scrawl.group,
-      'chair': ['Kim Hamilton Duffy', 'Wayne Chang', 'Heather Vescent']
-        .sort(function(){return (4*Math.random()>2)?1:-1}),
+      'chair': scrawl.chairs,
       'present': {},
       'scribe': [],
       'topics': [],


### PR DESCRIPTION
There are a many quirks about the CCG scripts that make them tricky to use for task forces. I'm going to submit a couple of PRs as an FYI (but you can merge them if you want), or conveniences that would make this easier to use.

This simple one introduces a config.json that can be used to modify the task force chair lists that was previously hard-coded in scrawl.js. Either way, it's probably good to move this to a config, because it is so buried in the code and hard to find.

/cc @rhiaro @wyc 

And feel free to add other IFTF members