### PR TITLE
Add 2021-06-08 minutes

### DIFF
--- a/.github/workflows/update_minutes.yml
+++ b/.github/workflows/update_minutes.yml
@@ -2,6 +2,8 @@ name: Update minutes
 
 on:
   push:
+    branches:
+    - gh-pages
     paths:
     - '**/irc.log'
 

--- a/2021-06-08/group.txt
+++ b/2021-06-08/group.txt
@@ -1,0 +1,1 @@
+Credentials CG

--- a/2021-06-08/irc.log
+++ b/2021-06-08/irc.log
@@ -9,14 +9,14 @@
 [2021-06-08T16:02:46.386Z]	<Dmitri_Z>	present+
 [2021-06-08T16:02:51.201Z]	<chriswinc>	present+
 [2021-06-08T16:04:23.030Z]	<econnell>	present+
-[2021-06-08T16:04:49.059Z]	<rgant>	present+
-[2021-06-08T16:05:13.504Z]	<rgant>	present+
+[2021-06-08T16:04:49.059Z]	<rgrant>	present+
+[2021-06-08T16:05:13.504Z]	<rgrant>	present+
 [2021-06-08T16:05:25.250Z]	<chriswinc>	I can scribe Wayne
 [2021-06-08T16:05:28.252Z]	<econnell>	present+
 [2021-06-08T16:05:30.274Z]	<chriswinc>	scribe+
 [2021-06-08T16:05:47.503Z]	<Orie>	present+
 [2021-06-08T16:05:47.734Z]	<rgrant>	present+
-[2021-06-08T16:06:14.996Z]	<Wayne_Chang>	https://lists.w3.org/Archives/Public/public-credentials/2021Jun/0054.html
+[2021-06-08T16:06:14.996Z]	<Wayne_Chang>	agenda: https://lists.w3.org/Archives/Public/public-credentials/2021Jun/0054.html
 [2021-06-08T16:06:26.303Z]	<TallTed_//_Ted_Thibodeau_(he/him)_(openlinksw.com)>	present+
 [2021-06-08T16:07:06.858Z]	<chriswinc>	Topic: Eip712Signature2021
 [2021-06-08T16:07:23.849Z]	<Wayne_Chang>	https://uport-project.github.io/ethereum-eip712-signature-2021-spec/
@@ -24,7 +24,7 @@
 [2021-06-08T16:07:33.507Z]	<Wayne_Chang>	https://github.com/w3c-ccg/community/issues/194
 [2021-06-08T16:08:07.898Z]	<Heather_Vescent>	present+
 [2021-06-08T16:08:13.541Z]	<chriswinc>	wayne: We will open it up after this topic to discuss other topics people want on the agenda
-[2021-06-08T16:08:18.517Z]	<Phil.L>	present +
+[2021-06-08T16:08:18.517Z]	<Phil.L>	present+
 [2021-06-08T16:08:27.800Z]	<Julien_Fraichot>	present+
 [2021-06-08T16:08:51.408Z]	<chriswinc>	...Goal is to issue LD credentials compliant with Ethereum signing requirements
 [2021-06-08T16:08:54.878Z]	<heathervescent>	present+
@@ -65,7 +65,6 @@
 [2021-06-08T16:16:33.462Z]	<chriswinc>	I can't hear Orie
 [2021-06-08T16:16:39.152Z]	<rgrant>	i can
 [2021-06-08T16:16:42.839Z]	<Heather_Vescent>	I can hear you Orie
-[2021-06-08T16:16:50.751Z]	<Wayne_Chang>	scribe+
 [2021-06-08T16:17:25.888Z]	<Wayne_Chang>	Orie: part of the universal wallet interop spec was the relationship between cryptocurrencies, blockchain identifiers, VCs, etc. all of these things are related in that people use the words "wallet" to describe various aspects of this. keys are used to xfer cryptocurrencies
 [2021-06-08T16:17:57.283Z]	<Wayne_Chang>	Orie: keys are used to sign VCs. the statements about non-repudiation are likely too technical to go to now, but you can do it without hardware-bound keys.
 [2021-06-08T16:18:02.446Z]	<Chris_Winczewski>	present+
@@ -128,6 +127,7 @@ https://github.com/w3c-ccg/ld-cryptosuite-registry
 [2021-06-08T16:34:07.990Z]	<chriswinc>	wayne: Should we start an issue to create an explainer?
 [2021-06-08T16:34:24.471Z]	<Wayne_Chang>	q?
 [2021-06-08T16:34:29.605Z]	<chriswinc>	heathervescent: Yes, and I am willing to edit if others prepare the work.
+[2021-06-08T16:34:35.000Z]	<cel>	topic: Announcements & Community Topics
 [2021-06-08T16:34:48.677Z]	<identitywoman>	https://wiki.trustoverip.org/display/HOME/GHP+Blueprint+Public+Review+Process
 [2021-06-08T16:35:15.449Z]	<chriswinc>	identitywoman: The good health pass has reached draft stage yesterday with 10 days of review
 [2021-06-08T16:35:35.404Z]	<Orie>	https://github.com/decentralized-identity/waci-presentation-exchange/

--- a/2021-06-08/irc.log
+++ b/2021-06-08/irc.log
@@ -47,7 +47,7 @@
 [2021-06-08T16:13:13.207Z]	<chriswinc>	agropper: What is the relationship between Metamask and blockchain wallets?
 [2021-06-08T16:13:16.645Z]	<Heather_Vescent>	q+
 [2021-06-08T16:13:23.348Z]	<rgrant>	q+ asking more about eip712
-[2021-06-08T16:13:24.716Z]	<Orie>	Adrian: https://w3c-ccg.github.io/universal-wallet-interop-spec/
+[2021-06-08T16:13:24.716Z]	<Orie>	Adrian : https://w3c-ccg.github.io/universal-wallet-interop-spec/
 [2021-06-08T16:13:42.354Z]	<Orie>	Specifically: https://w3c-ccg.github.io/universal-wallet-interop-spec/#Address
 [2021-06-08T16:13:46.108Z]	<chriswinc>	wayne: Difficult to issue JWT with Metamask
 [2021-06-08T16:14:19.053Z]	<chriswinc>	agropper: Under what circumstances do you use two wallets?

--- a/2021-06-08/irc.log
+++ b/2021-06-08/irc.log
@@ -1,0 +1,195 @@
+[2021-06-08T15:59:36.310Z]	<Wayne_Chang>	present+
+[2021-06-08T15:59:41.414Z]	<JeffO-StL>	present+
+[2021-06-08T16:01:19.241Z]	<Adrian_Gropper>	present+
+[2021-06-08T16:01:40.043Z]	<Chris_Winczewski>	present+
+[2021-06-08T16:02:01.385Z]	<Wayne_Chang>	present+
+[2021-06-08T16:02:02.195Z]	<agropper>	present+
+[2021-06-08T16:02:15.772Z]	<JeffO-StL>	present+
+[2021-06-08T16:02:18.348Z]	<Wayne_Chang>	https://lists.w3.org/Archives/Public/public-credentials/2021Jun/0054.html
+[2021-06-08T16:02:46.386Z]	<Dmitri_Z>	present+
+[2021-06-08T16:02:51.201Z]	<chriswinc>	present+
+[2021-06-08T16:04:23.030Z]	<econnell>	present+
+[2021-06-08T16:04:49.059Z]	<rgant>	present+
+[2021-06-08T16:05:13.504Z]	<rgant>	present+
+[2021-06-08T16:05:25.250Z]	<chriswinc>	I can scribe Wayne
+[2021-06-08T16:05:28.252Z]	<econnell>	present+
+[2021-06-08T16:05:30.274Z]	<chriswinc>	scribe+
+[2021-06-08T16:05:47.503Z]	<Orie>	present+
+[2021-06-08T16:05:47.734Z]	<rgrant>	present+
+[2021-06-08T16:06:14.996Z]	<Wayne_Chang>	https://lists.w3.org/Archives/Public/public-credentials/2021Jun/0054.html
+[2021-06-08T16:06:26.303Z]	<TallTed_//_Ted_Thibodeau_(he/him)_(openlinksw.com)>	present+
+[2021-06-08T16:07:06.858Z]	<chriswinc>	Topic: Eip712Signature2021
+[2021-06-08T16:07:23.849Z]	<Wayne_Chang>	https://uport-project.github.io/ethereum-eip712-signature-2021-spec/
+[2021-06-08T16:07:30.435Z]	<Phil.L>	present+
+[2021-06-08T16:07:33.507Z]	<Wayne_Chang>	https://github.com/w3c-ccg/community/issues/194
+[2021-06-08T16:08:07.898Z]	<Heather_Vescent>	present+
+[2021-06-08T16:08:13.541Z]	<chriswinc>	wayne: We will open it up after this topic to discuss other topics people want on the agenda
+[2021-06-08T16:08:18.517Z]	<Phil.L>	present +
+[2021-06-08T16:08:27.800Z]	<Julien_Fraichot>	present+
+[2021-06-08T16:08:51.408Z]	<chriswinc>	...Goal is to issue LD credentials compliant with Ethereum signing requirements
+[2021-06-08T16:08:54.878Z]	<heathervescent>	present+
+[2021-06-08T16:08:59.726Z]	<Markus_Sabadello>	present+
+[2021-06-08T16:09:13.819Z]	<chriswinc>	...This is an LD proof mechanism using a crypto wallet
+[2021-06-08T16:09:48.141Z]	<chriswinc>	...and usable with Metamask
+[2021-06-08T16:10:13.029Z]	<Orie>	I think their implementation uses JCS instead of URDNA2015
+[2021-06-08T16:10:26.347Z]	<chriswinc>	...Oliver did most of the work but was unable to join so I am presenting on his behalf
+[2021-06-08T16:10:28.980Z]	<Orie>	an approach similar to workday signature suite
+[2021-06-08T16:11:09.239Z]	<chriswinc>	...Digest and Signature algorithm is the same that Ethereum uses
+[2021-06-08T16:11:52.490Z]	<Orie>	signing arbitrary data is dangerous? I thought that was a feature of JWTs :)
+[2021-06-08T16:11:57.930Z]	<Orie>	/s
+[2021-06-08T16:12:03.993Z]	<chriswinc>	...Many wallets in the Ethereum ecosystem are compliant with this
+[2021-06-08T16:12:26.871Z]	<Charles_E._Lehner>	present+
+[2021-06-08T16:12:32.096Z]	<chriswinc>	...Well timed with the LD Signature work to show the flexibility and usage
+[2021-06-08T16:12:36.101Z]	<Heather_Vescent>	Thanks Wayne, sorry I was late, previous call ran over.
+[2021-06-08T16:12:36.238Z]	<Wayne_Chang>	q?
+[2021-06-08T16:13:00.216Z]	<Orie>	q+
+[2021-06-08T16:13:02.920Z]	<Jeff_Stephens>	present+
+[2021-06-08T16:13:13.207Z]	<chriswinc>	agropper: What is the relationship between Metamask and blockchain wallets?
+[2021-06-08T16:13:16.645Z]	<Heather_Vescent>	q+
+[2021-06-08T16:13:23.348Z]	<rgrant>	q+ asking more about eip712
+[2021-06-08T16:13:24.716Z]	<Orie>	Adrian: https://w3c-ccg.github.io/universal-wallet-interop-spec/
+[2021-06-08T16:13:42.354Z]	<Orie>	Specifically: https://w3c-ccg.github.io/universal-wallet-interop-spec/#Address
+[2021-06-08T16:13:46.108Z]	<chriswinc>	wayne: Difficult to issue JWT with Metamask
+[2021-06-08T16:14:19.053Z]	<chriswinc>	agropper: Under what circumstances do you use two wallets?
+[2021-06-08T16:14:31.710Z]	<chriswinc>	...does non-repudiation require a third?
+[2021-06-08T16:15:15.498Z]	<Orie>	yikes to everything that is being said about "non-repudiation"
+[2021-06-08T16:15:31.012Z]	<chriswinc>	agropper: Healthcare normally requires hardware token
+[2021-06-08T16:15:38.232Z]	<IdentityWoman>	present+
+[2021-06-08T16:16:08.818Z]	<cel>	cryptocurrency wallets may be used with hardware tokens
+[2021-06-08T16:16:10.933Z]	<Matthieu_Collé>	present+
+[2021-06-08T16:16:13.828Z]	<chriswinc>	wayne: Need separate topic to look at healthcare
+[2021-06-08T16:16:16.792Z]	<identitywoman>	sorry I'm late - did we already do annoucements? I have one
+[2021-06-08T16:16:18.807Z]	<Wayne_Chang>	q?
+[2021-06-08T16:16:19.195Z]	<Heather_Vescent>	q?
+[2021-06-08T16:16:21.582Z]	<Wayne_Chang>	ack Orie
+[2021-06-08T16:16:33.462Z]	<chriswinc>	I can't hear Orie
+[2021-06-08T16:16:39.152Z]	<rgrant>	i can
+[2021-06-08T16:16:42.839Z]	<Heather_Vescent>	I can hear you Orie
+[2021-06-08T16:16:50.751Z]	<Wayne_Chang>	scribe+
+[2021-06-08T16:17:25.888Z]	<Wayne_Chang>	Orie: part of the universal wallet interop spec was the relationship between cryptocurrencies, blockchain identifiers, VCs, etc. all of these things are related in that people use the words "wallet" to describe various aspects of this. keys are used to xfer cryptocurrencies
+[2021-06-08T16:17:57.283Z]	<Wayne_Chang>	Orie: keys are used to sign VCs. the statements about non-repudiation are likely too technical to go to now, but you can do it without hardware-bound keys.
+[2021-06-08T16:18:02.446Z]	<Chris_Winczewski>	present+
+[2021-06-08T16:18:24.857Z]	<Wayne_Chang>	Orie: we tried to go over this in the universal wallet specification, and we'd love to continue the conversation there to answer those questions.
+[2021-06-08T16:18:31.560Z]	<Wayne_Chang>	q?
+[2021-06-08T16:18:35.343Z]	<Orie>	https://w3c-ccg.github.io/universal-wallet-interop-spec/#Address
+[2021-06-08T16:18:55.438Z]	<Wayne_Chang>	ack Heather
+[2021-06-08T16:19:20.845Z]	<chriswinc>	heathervescent: Thank you for answering the questions.
+[2021-06-08T16:19:44.267Z]	<chriswinc>	...Are you making it so that Eth wallets can hold and issue VC's?
+[2021-06-08T16:20:06.380Z]	<chriswinc>	wayne: Issuance and signing, yes. Holding and verifying not the current focus
+[2021-06-08T16:20:54.505Z]	<Phil.L>	When the wallet "issues a credential"  are you not creating a presentation in this case?
+[2021-06-08T16:21:07.284Z]	<chriswinc>	heathervescent: That was the "what," how is this accomplished?
+[2021-06-08T16:21:28.410Z]	<chriswinc>	wayne: The signature suite
+[2021-06-08T16:22:26.969Z]	<chriswinc>	heathervescent: There are many different signature suites. Is there a way to categorize what this does to aid in repo cleanup?
+[2021-06-08T16:22:47.670Z]	<chriswinc>	wayne: This may be part of the up and coming working group to handle
+[2021-06-08T16:23:18.460Z]	<Phil.L>	Q+
+[2021-06-08T16:23:33.572Z]	<chriswinc>	wayne: Would love to work with the working group members on structure
+[2021-06-08T16:23:44.269Z]	<Wayne_Chang>	ack rgant
+[2021-06-08T16:23:52.020Z]	<Wayne_Chang>	ack rgrant
+[2021-06-08T16:23:56.868Z]	<Orie>	I'm supportive of the work item (speaking for Transmute)
+[2021-06-08T16:24:37.194Z]	<chriswinc>	rgrant: Question about eip712. What is the intent?
+[2021-06-08T16:25:17.801Z]	<chriswinc>	wayne: Looking at claim data standards into eip712 for use in Metamask
+[2021-06-08T16:25:28.426Z]	<agropper>	q+
+[2021-06-08T16:25:31.748Z]	<chriswinc>	...Signature then to be compliant with VC
+[2021-06-08T16:26:24.895Z]	<chriswinc>	rgrant: Wallet is responsible for taking JSON-LD and presenting in an eip712 format?
+[2021-06-08T16:26:43.719Z]	<chriswinc>	wayne: Yes. Companion work should include an explainer.
+[2021-06-08T16:27:08.170Z]	<Wayne_Chang>	q?
+[2021-06-08T16:27:10.093Z]	<Wayne_Chang>	ack Phil
+[2021-06-08T16:27:15.523Z]	<chriswinc>	...Metamask supports multiple accounts and wallets.
+[2021-06-08T16:27:36.206Z]	<David_Lehn>	present+
+[2021-06-08T16:27:51.244Z]	<Orie>	Linked Data Proof suites are used for both Verifiable Credentials and Verifiable Presentations
+[2021-06-08T16:28:07.137Z]	<Orie>	Issuers Issue VCs, Holders Present VPs
+[2021-06-08T16:28:22.199Z]	<Wayne_Chang>	q?
+[2021-06-08T16:28:24.241Z]	<chriswinc>	wayne: Primarily relying on signature component vs holding within the wallet.
+[2021-06-08T16:28:24.983Z]	<Wayne_Chang>	ack agropper
+[2021-06-08T16:29:06.364Z]	<chriswinc>	agropper: This sounds like it has little to do with the signature suite but rather what is presented to you
+[2021-06-08T16:29:49.857Z]	<chriswinc>	...Metamask has a vested interest to present accurately
+[2021-06-08T16:30:09.144Z]	<Orie>	Similar examples of Linked Data Proof suites:
+
+https://github.com/w3c-ccg/ld-cryptosuite-registry
+[2021-06-08T16:30:21.683Z]	<Heather_Vescent>	Thanks for that questions agropper.
+[2021-06-08T16:30:24.518Z]	<Heather_Vescent>	q+
+[2021-06-08T16:30:28.671Z]	<chriswinc>	wayne: Not just Metamask but all wallets compliant with eip712
+[2021-06-08T16:30:43.753Z]	<identitywoman>	I made a comment up above about whether announcements already happened - I was late. I have one.
+[2021-06-08T16:30:47.146Z]	<Orie>	nothing could be safer than javascript crypto in a web browser.
+[2021-06-08T16:30:55.552Z]	<Orie>	/s
+[2021-06-08T16:31:01.609Z]	<Heather_Vescent>	(I also have an announcement and joined late too wayne)
+[2021-06-08T16:31:07.531Z]	<Heather_Vescent>	(But my q+ is not for that)
+[2021-06-08T16:31:13.962Z]	<chriswinc>	agropper: The reason you are doing this in LD context is that this is easier to check, thus reliability?
+[2021-06-08T16:31:16.870Z]	<chriswinc>	wayne: yes
+[2021-06-08T16:31:54.621Z]	<chriswinc>	wayne: This is possible with LD proofs and not JWT
+[2021-06-08T16:32:12.188Z]	<chriswinc>	...Significant code changes to such a high security format is unlikely
+[2021-06-08T16:32:16.811Z]	<cel>	ethereum signing for JWT would need a new JWS algorithm registered
+[2021-06-08T16:32:20.351Z]	<Wayne_Chang>	q?
+[2021-06-08T16:32:25.032Z]	<Wayne_Chang>	ack Heather
+[2021-06-08T16:32:41.101Z]	<Orie>	another version of what wayne is saying is that IANA is unlikely to register an eip712 `alg` field any time soon :0
+[2021-06-08T16:32:46.180Z]	<chriswinc>	heathervescent: thank you wayne for bringing this to the meeting
+[2021-06-08T16:33:47.794Z]	<agropper>	I'm happy to help on what Hearher's suggesting
+[2021-06-08T16:33:49.341Z]	<chriswinc>	...this is a heavy lift to understand the excitement about what is being proposed. Can we summarize this or add a README to describe what is being accomplished here?
+[2021-06-08T16:34:07.990Z]	<chriswinc>	wayne: Should we start an issue to create an explainer?
+[2021-06-08T16:34:24.471Z]	<Wayne_Chang>	q?
+[2021-06-08T16:34:29.605Z]	<chriswinc>	heathervescent: Yes, and I am willing to edit if others prepare the work.
+[2021-06-08T16:34:48.677Z]	<identitywoman>	https://wiki.trustoverip.org/display/HOME/GHP+Blueprint+Public+Review+Process
+[2021-06-08T16:35:15.449Z]	<chriswinc>	identitywoman: The good health pass has reached draft stage yesterday with 10 days of review
+[2021-06-08T16:35:35.404Z]	<Orie>	https://github.com/decentralized-identity/waci-presentation-exchange/
+[2021-06-08T16:35:50.037Z]	<chriswinc>	...Specify formats and interop
+[2021-06-08T16:36:13.393Z]	<chriswinc>	...how to we get credentials to be exchanged for international travel
+[2021-06-08T16:36:39.087Z]	<chriswinc>	heathervescent: Last Friday rgrant and I met on how to record minutes
+[2021-06-08T16:36:49.281Z]	<agropper>	q+
+[2021-06-08T16:37:03.454Z]	<chriswinc>	...It is recorded and details the process
+[2021-06-08T16:37:23.532Z]	<chriswinc>	...Point 2, VC's for Ed will be added to the 101 series
+[2021-06-08T16:37:31.291Z]	<Wayne_Chang>	q?
+[2021-06-08T16:37:31.631Z]	<Orie>	q?
+[2021-06-08T16:37:35.252Z]	<Wayne_Chang>	ack agrop
+[2021-06-08T16:37:37.051Z]	<chriswinc>	wayne: Are there topics that the community would like to discuss?
+[2021-06-08T16:38:08.232Z]	<chriswinc>	agropper: Would like to talk about how VCs go from the issuer to the verifier in the context of vaccine credentials
+[2021-06-08T16:38:15.364Z]	<Orie>	verifiable credentials don't go from the issuer to the verifier, without the consent of the holder...
+[2021-06-08T16:38:25.937Z]	<chriswinc>	...Topic would be called "Authorization"
+[2021-06-08T16:39:30.234Z]	<Wayne_Chang>	q?
+[2021-06-08T16:39:30.529Z]	<chriswinc>	wayne: Others? We should send a survey after this since this is a bit on the spot
+[2021-06-08T16:39:46.073Z]	<chriswinc>	agropper: Geotrust architecture
+[2021-06-08T16:40:07.228Z]	<Wayne_Chang>	"Zero Trust"
+[2021-06-08T16:40:12.524Z]	<chriswinc>	...as a result of the executive order for Zero Trust Architecture (not geotrust)
+[2021-06-08T16:40:36.226Z]	<Wayne_Chang>	q+
+[2021-06-08T16:40:56.144Z]	<Wayne_Chang>	ack Wayne
+[2021-06-08T16:41:15.985Z]	<chriswinc>	wayne: I would like to talk about normalization and growing privacy
+[2021-06-08T16:41:30.432Z]	<chriswinc>	...Apple just released Identity on the phone
+[2021-06-08T16:41:48.494Z]	<Orie>	https://www.aclu.org/news/privacy-technology/digital-ids-might-sound-like-a-good-idea-but-they-could-be-a-privacy-nightmare/
+[2021-06-08T16:41:56.628Z]	<chriswinc>	...We should assume this is coming and nations are moving to digital identity
+[2021-06-08T16:42:15.156Z]	<Orie>	q+
+[2021-06-08T16:42:19.330Z]	<Wayne_Chang>	ack Orie
+[2021-06-08T16:42:22.942Z]	<chriswinc>	...what are the risks?
+[2021-06-08T16:42:39.476Z]	<chriswinc>	Orie: Should we ask EFF or ACLU to come talk to us?
+[2021-06-08T16:42:47.565Z]	<identitywoman>	The ACLU just put out an anti mDL paper - but in that said nice things about VCs :)
+[2021-06-08T16:42:54.335Z]	<identitywoman>	I know the author.
+[2021-06-08T16:43:01.140Z]	<agropper>	+1 to ACLU or EFF on this
+[2021-06-08T16:43:02.164Z]	<Heather_Vescent>	+1 Orie
+[2021-06-08T16:43:03.831Z]	<chriswinc>	...It would be great to hear from these groups
+[2021-06-08T16:43:07.000Z]	<Wayne_Chang>	q?
+[2021-06-08T16:43:07.698Z]	<manu>	Yes, let's please invite them in and have a discussion with them!
+[2021-06-08T16:43:37.684Z]	<Phil.L>	Q+
+[2021-06-08T16:43:41.235Z]	<Wayne_Chang>	ack Phil
+[2021-06-08T16:44:23.749Z]	<chriswinc>	Phil.L: In Edu, the interest in the richness of metadata to represent achievements is growing
+[2021-06-08T16:44:32.965Z]	<identitywoman>	You might want to use an EDV :)
+[2021-06-08T16:44:50.022Z]	<chriswinc>	...There is an issue about the structure of credentials
+[2021-06-08T16:45:05.590Z]	<agropper>	+1 Phil - it's all about authorization
+[2021-06-08T16:45:31.113Z]	<chriswinc>	wayne: I was personally interested in microcredentials
+[2021-06-08T16:45:41.768Z]	<chriswinc>	...OpenBadges will supported
+[2021-06-08T16:46:31.013Z]	<chriswinc>	Phil.L: I am part of this group. A topic is an evidence array which can point to (URI) evidence that may be too big to pack into a credential.
+[2021-06-08T16:47:10.601Z]	<chriswinc>	...Assertions related to the course curriculum or achievement is also requested.
+[2021-06-08T16:47:54.891Z]	<chriswinc>	identitywoman: If anyone is interested, I can talk about my book "The Domains of Identity"
+[2021-06-08T16:48:16.070Z]	<Wayne_Chang>	q+
+[2021-06-08T16:48:17.964Z]	<Wayne_Chang>	ack Wayne_Chang
+[2021-06-08T16:48:36.816Z]	<chriswinc>	wayne: The may be a chance of mandated interoperability
+[2021-06-08T16:48:45.375Z]	<chriswinc>	...recent chatter at FCC
+[2021-06-08T16:49:07.763Z]	<chriswinc>	...called Competitive Interoperability for anti-trust
+[2021-06-08T16:49:24.076Z]	<chriswinc>	...Competitive Compatibility
+[2021-06-08T16:49:25.414Z]	<Wayne_Chang>	q?
+[2021-06-08T16:49:58.101Z]	<rgrant>	https://www.eff.org/deeplinks/2020/12/competitive-compatibility-year-review
+[2021-06-08T16:50:05.459Z]	<chriswinc>	agropper: Is this like open banking?
+[2021-06-08T16:50:19.571Z]	<chriswinc>	wayne: yes, possibly like PSD2
+[2021-06-08T16:51:01.044Z]	<chriswinc>	...In the EU, one market that is competitive for all citizens, not just those locally
+[2021-06-08T16:51:35.112Z]	<chriswinc>	agropper: relates to authorization. Control is consolidated around processor. Therefore, we need regulations.
+[2021-06-08T16:51:40.300Z]	<Wayne_Chang>	q?
+[2021-06-08T16:52:06.344Z]	<chriswinc>	wayne: What about ESSIF?
+[2021-06-08T16:53:03.211Z]	<chriswinc>	...Should we broaden to other regional initiatives (e.g. DHS, BC, Singapore)?
+[2021-06-08T16:54:27.076Z]	<Wayne_Chang>	kicking to stop meeting in 3 seonds...

--- a/scribe-tool/scrawl.js
+++ b/scribe-tool/scrawl.js
@@ -523,7 +523,7 @@
        // the line is a comment by somebody else
        else if(nick != context.scribenick)
        {
-         if(msg.indexOf(':') != -1)
+         if(/^\S+:/.test(msg))
          {
            var alias = msg.split(':', 1)[0].replace(' ', '').toLowerCase();
 

--- a/scribe-tool/scrawl.js
+++ b/scribe-tool/scrawl.js
@@ -7,7 +7,7 @@
   var $ = (typeof jQuery !== 'undefined') ? jQuery : undefined;
   /* Standard regular expressions to use when matching lines */
   var commentRx = /^\[?(.*)\]?\s+\<(.*)\>\s+(.*)$/;
-  var scribeRx = /^(scribe|scribenick):.*$/i;
+  var scribeRx = /^(scribe|scribenick):.*$|scribe\+/i;
   var meetingRx = /^meeting:\s(.*)$/i;
   var totalPresentRx = /^total present:\s(.*)$/i;
   var dateRx = /^date:\s(.*)$/i;
@@ -333,7 +333,12 @@
        // check for a scribe line
        if(msg.search(scribeRx) != -1)
        {
-         var scribe = msg.split(':')[1].replace(' ', '');
+         var scribe;
+         if(msg.includes('scribe+')) {
+           scribe = nick;
+         } else {
+           scribe = msg.split(':')[1].replace(' ', '');
+         }
          scribe = scribe.toLowerCase();
          context.scribenick = scribe;
          if(scribe in aliases)

--- a/scribe-tool/scrawl.js
+++ b/scribe-tool/scrawl.js
@@ -404,7 +404,7 @@
                 scrawl.present(context, aliases[lastName]);
               } else {
                 if(msg.includes('present+')) {
-                  scrawl.present(context, match[2].replace('_', ' '));
+                  scrawl.present(context, match[2].replace(/_/g, ' '));
                 } else {
                   console.log('Could not find alias for', person);
                 }


### PR DESCRIPTION
Add 2021-06-08 minutes, and other various changes

- Add 2021-06-08 IRC and audio (not adding HTML, as the auto-commit does that).
- Enable `scribe+` which some people use (possibly because [scribe.perl](https://w3c.github.io/scribe2/scribedoc.html) uses it in the DID WG).
- Convert underscores in nicks to spaces, beyond the first one, to improve rendering of some names.
- Run CI with auto-commits only on the gh-pages branch.