### PR TITLE
fix: allow irc.log with CRLF line endings

### DIFF
--- a/scribe-tool/scrawl.js
+++ b/scribe-tool/scrawl.js
@@ -85,7 +85,7 @@
     }
 
     // extract all names from present list
-    var ircLines = ircLog.split('\n');
+    var ircLines = ircLog.split(/\r?\n/);
     var presentList = [];
     for(var line of ircLines) {
       var match = commentRx.exec(line);
@@ -871,7 +871,7 @@
     var rval = '';
     var minutes = '';
     var summary = '';
-    var ircLines = ircLog.split('\n');
+    var ircLines = ircLog.split(/\r?\n/);
     var aliases = scrawl.generateAliases(ircLog);
     scrawl.counter = 0;
 


### PR DESCRIPTION
Line endings of LF were assumed, breaking generation of minutes and aliases when irc.log gets created with CRLF, e.g., on Windows.

FIX #84