### PR TITLE
Add video archive link.

### DIFF
--- a/scribe-tool/index.js
+++ b/scribe-tool/index.js
@@ -76,6 +76,8 @@ function generateEmailBody() {
       'Full text of the discussion follows for W3C archival purposes.\n' +
       'Audio of the meeting is available at the following location:\n\n' +
       `https://w3c-ccg.github.io/meetings/${program.directory}/audio.ogg\n\n` +
+      `A video recording is also available at:\n\n` +
+      `https://meet.w3c-ccg.org/archives/w3c-ccg-${scrawl.group.id}-${gDate}.mp4\n\n` +
       '----------------------------------------------------------------\n' +
       content;
   return content;


### PR DESCRIPTION
I'm not confident about the URL construction, but if the video archive uses the same "directory" naming as the audio archiving, this should work. If not, I can change this to use only the event date. Just let me know!

Here's an example of a working video recording link:
https://meet.w3c-ccg.org/archives/w3c-ccg-weekly-2023-11-07.mp4 