### PR TITLE
Upgrade all the GitHub action deps to latest.

### DIFF
--- a/.github/workflows/download_raw_minutes.yml
+++ b/.github/workflows/download_raw_minutes.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Setup custom environment variables
       run: git config --global push.default simple && git config --global user.email "w3c.ccg@gmail.com" && git config --global user.name "W3C CCG"
     - name: Pull raw meeting log file
@@ -26,7 +26,7 @@ jobs:
         fi
         bash ./download-minutes.sh
       shell: bash 
-    - uses: stefanzweifel/git-auto-commit-action@v2.5.0
+    - uses: stefanzweifel/git-auto-commit-action@v5
       with:
         commit_message: Add raw log for telecon [ci skip]
         branch: main

--- a/.github/workflows/generate_minutes.yml
+++ b/.github/workflows/generate_minutes.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Setup custom environment variables
       run: git config --global push.default simple && git config --global user.email "w3c.ccg@gmail.com" && git config --global user.name "W3C CCG"
     - name: Pull raw meeting log file
@@ -39,7 +39,7 @@ jobs:
         DATE: ${{ steps.pull_raw_file.outputs.date }}
         DIR: ${{ steps.pull_raw_file.outputs.dir}}
         GROUP: ${{ steps.pull_raw_file.outputs.group }}
-    - uses: stefanzweifel/git-auto-commit-action@v2.5.0
+    - uses: stefanzweifel/git-auto-commit-action@v5
       with:
         commit_message: Add minutes for telecon [ci skip]
         branch: main

--- a/.github/workflows/update_minutes.yml
+++ b/.github/workflows/update_minutes.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - id: file_changes
@@ -57,7 +57,7 @@ jobs:
         DIR: ${{ steps.detect_file.outputs.dir }}
         GROUP: ${{ steps.detect_file.outputs.group }}
 
-    - uses: stefanzweifel/git-auto-commit-action@v2.5.0
+    - uses: stefanzweifel/git-auto-commit-action@v5
       with:
         commit_message: Add html minutes for telecon [ci skip]
         branch: main
@@ -66,7 +66,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Send email
-      uses: dawidd6/action-send-mail@v1.3.0
+      uses: dawidd6/action-send-mail@v3
 
       with:
         server_address: mail.gandi.net


### PR DESCRIPTION
This blindly updates the dependencies used in the GitHub Action. Lacking a local way to test this, it feels attempting this first and then seeing what email stuff may be broken second, makes the most sense (since these upgrades are healthy anyhow).